### PR TITLE
feat(frontend): upload + metrics + CSV export; backend: enable CORS f…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+frontend/.env
+backend/__pycache__/main.cpython-311.pyc
+frontend/.env
+backend/.env

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,19 @@ os.environ["OGR_GEOMETRY_ACCEPT_UNCLOSED_RING"] = "YES"
 
 app = FastAPI(title="FairMap Backend", version="1.0")
 
+# --- CORS middleware (added so React frontend can call backend) ---
+from fastapi.middleware.cors import CORSMiddleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+    ],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 # Define input model for predictions
 class PredictionInput(BaseModel):
     historical_votes: list  # e.g., [Dem_votes, Rep_votes]
@@ -25,15 +38,14 @@ SHAPEFILE_EXTENSIONS = [".shp", ".shx", ".dbf", ".prj", ".cpg"]
 # --- Constants End -------------------------------------------------------------------------
 
 # --- Utility Functions ---------------------------------------------------------------------
-# Used in /upload-map function with SUPPORTED_FILE_TYPES constant 
 def validate_file_type(filename: str):
     """Check if the uploaded file has a supported extension."""
     if not any(filename.endswith(ext) for ext in SUPPORTED_FILE_TYPES):
         raise HTTPException(
-            status_code=400, 
+            status_code=400,
             detail=f"Invalid file type. Supported types: {', '.join(SUPPORTED_FILE_TYPES)}"
         )
-# Used in /upload-map function to read and used to return content of geojson
+
 def read_geojson(file: UploadFile) -> gpd.GeoDataFrame:
     """Read a GeoJSON file into a GeoDataFrame."""
     try:
@@ -42,7 +54,7 @@ def read_geojson(file: UploadFile) -> gpd.GeoDataFrame:
         return gdf
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to read GeoJSON: {str(e)}")
-# Used in /upload-map function to reads shapefiles     
+
 def read_shapefile(zip_file: UploadFile) -> gpd.GeoDataFrame:
     """Read a zipped shapefile into a GeoDataFrame safely."""
     try:
@@ -51,7 +63,7 @@ def read_shapefile(zip_file: UploadFile) -> gpd.GeoDataFrame:
             zip_path = os.path.join(tmpdir, zip_file.filename)
             with open(zip_path, "wb") as f:
                 f.write(zip_file.file.read())
-            
+
             # Extract zip
             with zipfile.ZipFile(zip_path, 'r') as zip_ref:
                 zip_ref.extractall(tmpdir)
@@ -60,21 +72,17 @@ def read_shapefile(zip_file: UploadFile) -> gpd.GeoDataFrame:
             shp_files = [f for f in os.listdir(tmpdir) if f.endswith(".shp")]
             if not shp_files:
                 raise HTTPException(status_code=400, detail="No .shp file found in zip")
-            
+
             shp_path = os.path.join(tmpdir, shp_files[0])
             gdf = gpd.read_file(shp_path)
             return gdf
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to read shapefile: {str(e)}")
-# Used in /calculate-metrics function to extend calculations for fairness
+
 def calculate_basic_metrics(gdf: gpd.GeoDataFrame) -> dict:
-    """
-    Calculate placeholder fairness metrics.
-    This can be extended with real calculations like compactness, efficiency gap, etc.
-    """
+    """Placeholder fairness metrics (replace with real calculations)."""
     num_districts = len(gdf)
-    
-    # Placeholder metrics
+
     metrics = {
         "num_districts": num_districts,
         "compactness": 0.75,      # Replace with real calculation
@@ -84,18 +92,9 @@ def calculate_basic_metrics(gdf: gpd.GeoDataFrame) -> dict:
 # --- Utility Functions End ------------------------------------------------------------------
 
 # --- Endpoints ------------------------------------------------------------------------------
-# Upload Maps Endpoint
 @app.post("/upload-map")
 async def upload_map(file: UploadFile = File(...)):
-    """
-    Upload an electoral district map.
-    
-    Supports:
-    - GeoJSON
-    - Shapefile (as a zipped file containing .shp, .shx, .dbf, etc.)
-    
-    Returns metadata such as filename and number of districts.
-    """
+    """Upload an electoral district map (GeoJSON or zipped shapefile)."""
     validate_file_type(file.filename)
 
     if file.filename.endswith(".geojson"):
@@ -110,15 +109,10 @@ async def upload_map(file: UploadFile = File(...)):
         "num_districts": len(gdf),
         "status": "Map uploaded successfully"
     })
-# Calculate Metrics Endpoint
+
 @app.post("/calculate-metrics")
 async def calculate_metrics(file: UploadFile):
-    """
-    Calculate fairness metrics for an uploaded electoral district map.
-    Supports:
-    - GeoJSON
-    - Shapefile (as a zipped file)
-    """
+    """Calculate fairness metrics for an uploaded electoral district map."""
     validate_file_type(file.filename)
 
     if file.filename.endswith(".geojson"):
@@ -135,22 +129,14 @@ async def calculate_metrics(file: UploadFile):
         "metrics": metrics,
         "status": "Metrics calculated successfully"
     })
-# Run Simulation Endpoint 
+
 @app.post("/run-simulation")
 async def run_simulation(simulation_params: dict):
-    """
-    Run an ensemble simulation on the uploaded map.
-    Example simulation_params:
-    {
-        "num_simulations": 100,
-        "metric_weights": {"compactness": 0.5, "efficiency_gap": 0.5}
-    }
-    """
+    """Run an ensemble simulation (dummy placeholder)."""
     try:
         num_simulations = simulation_params.get("num_simulations", 100)
         metric_weights = simulation_params.get("metric_weights", {"compactness": 1, "efficiency_gap": 1})
 
-        # Dummy simulation logic for now (replace with GerryChain later)
         simulated_results = [{"simulation": i, "score": i * 0.1} for i in range(num_simulations)]
 
         return JSONResponse(content={
@@ -164,11 +150,10 @@ async def run_simulation(simulation_params: dict):
 
 @app.post("/predict-outcome")
 async def predict_outcome(input_data: PredictionInput):
+    """Predict partisan outcomes (placeholder logic)."""
     try:
-        # Placeholder logic: simple weighted sum for demonstration
         dem_votes = input_data.historical_votes[0]
         rep_votes = input_data.historical_votes[1]
-        population_factor = input_data.demographics.get("population", 1)
 
         predicted_dem_share = (dem_votes / (dem_votes + rep_votes)) * 100
         predicted_rep_share = 100 - predicted_dem_share
@@ -184,31 +169,21 @@ async def predict_outcome(input_data: PredictionInput):
 
 @app.post("/export-report")
 async def export_report(request: Request):
-    """
-    Expects a JSON payload like:
-    {
-        "metrics": [{"district": "A", "score": 0.5}, ...]
-    }
-    Returns a CSV file containing the metrics.
-    """
+    """Export uploaded metrics as a CSV file."""
     try:
-        # Parse JSON body
         data = await request.json()
-
-        # Validate presence of "metrics"
         metrics = data.get("metrics")
+
         if not metrics or not isinstance(metrics, list):
             return JSONResponse(
                 status_code=400,
                 content={"detail": "Invalid payload: 'metrics' key missing or not a list"}
             )
 
-        # Create DataFrame and save CSV
         df = pd.DataFrame(metrics)
         file_path = "report.csv"
         df.to_csv(file_path, index=False)
 
-        # Return file response
         return FileResponse(
             path=file_path,
             filename="report.csv",
@@ -218,11 +193,6 @@ async def export_report(request: Request):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-    
 @app.get("/")
 async def root():
     return {"message": "FairMap backend is running"}
-
-
-def root():
-    return {"message": "FairMap backend running"}

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE=http://127.0.0.1:8000

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-router-dom": "^6.30.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -3073,6 +3074,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -13909,6 +13919,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,24 +1,40 @@
-import logo from './logo.svg';
-import './App.css';
+import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
+import "./App.css";
 
-function App() {
+import Upload from "./pages/Upload";
+import Metrics from "./pages/Metrics";
+import About from "./pages/About";
+
+function App()
+{
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <BrowserRouter>
+      <div className="App">
+        <nav style={{ padding: 12 }}>
+          <Link to="/" style={{ marginRight: 12 }}>Home</Link>
+          <Link to="/upload" style={{ marginRight: 12 }}>Upload</Link>
+          <Link to="/metrics" style={{ marginRight: 12 }}>Metrics</Link>
+          <Link to="/about">About</Link>
+        </nav>
+
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/upload" element={<Upload />} />
+          <Route path="/metrics" element={<Metrics />} />
+          <Route path="/about" element={<About />} />
+        </Routes>
+      </div>
+    </BrowserRouter>
+  );
+}
+
+function Home()
+{
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>FairMap</h1>
+      <p>Upload a district map, calculate metrics, and export a CSV report.</p>
+    </main>
   );
 }
 

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -1,0 +1,11 @@
+function About()
+{
+  return (
+    <main style={{ padding: 24 }}>
+      <h2>About</h2>
+      <p>CSC/ITC 492 project: Gerrymandering detection tool. Core metrics first; race-related
+         analysis optional depending on data access this year.</p>
+    </main>
+  );
+}
+export default About;

--- a/frontend/src/pages/Metrics.jsx
+++ b/frontend/src/pages/Metrics.jsx
@@ -1,0 +1,153 @@
+// src/pages/Metrics.jsx
+import { useState } from "react";
+
+const API = process.env.REACT_APP_API_BASE || "http://127.0.0.1:8000";
+
+function Metrics()
+{
+  const [file, setFile] = useState(null);
+  const [rows, setRows] = useState([]);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+
+  async function calculate(e)
+  {
+    e.preventDefault();
+    if (!file)
+    {
+      setErr("Please choose the same .geojson (or .zip shapefile) you uploaded.");
+      return;
+    }
+
+    try
+    {
+      setBusy(true);
+      setErr("");
+      const form = new FormData();
+      form.append("file", file);
+
+      // Backend expects POST multipart/form-data
+      const res = await fetch(`${API}/calculate-metrics`, {
+        method: "POST",
+        body: form,
+      });
+
+      if (!res.ok)
+      {
+        const text = await res.text();
+        throw new Error(text || `HTTP ${res.status}`);
+      }
+
+      const data = await res.json();
+      // Accept either { metrics: {...} } or an array normalize to table rows
+      const m = data.metrics;
+      if (Array.isArray(m))
+      {
+        setRows(m);
+      }
+      else if (m && typeof m === "object")
+      {
+        // If it's an object (for example {num_districts, compactness, efficiency_gap})
+        // show it as one-row table.
+        const objAsRow = { ...m };
+        setRows([objAsRow]);
+      }
+      else
+      {
+        setRows([]);
+      }
+    }
+    catch (e)
+    {
+      setErr(e.message);
+      setRows([]);
+    }
+    finally
+    {
+      setBusy(false);
+    }
+  }
+
+  async function exportCSV()
+  {
+    try
+    {
+      if (rows.length === 0)
+      {
+        setErr("No metrics to export. Click Calculate first.");
+        return;
+      }
+
+      const res = await fetch(`${API}/export-report`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ metrics: rows })
+      });
+
+      if (!res.ok)
+      {
+        const text = await res.text();
+        throw new Error(text || `Export failed (${res.status})`);
+      }
+
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "report.csv";
+      a.click();
+      window.URL.revokeObjectURL(url);
+    }
+    catch (e)
+    {
+      setErr(e.message);
+    }
+  }
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h2>Metrics</h2>
+
+      <form onSubmit={calculate} style={{ marginBottom: 12 }}>
+        <input
+          type="file"
+          accept=".geojson,.zip"
+          onChange={(e) => setFile(e.target.files?.[0] || null)}
+        />
+        <button type="submit" disabled={busy} style={{ marginLeft: 8 }}>
+          {busy ? "Calculating…" : "Calculate"}
+        </button>
+      </form>
+
+      {err && <p style={{ color: "red" }}>Error: {err}</p>}
+      {rows.length === 0 && !err && !busy && (
+        <p>Pick your map file, then click Calculate.</p>
+      )}
+
+      {rows.length > 0 && (
+        <>
+          <table border="1" cellPadding="8">
+            <thead>
+              <tr>
+                {Object.keys(rows[0]).map((k) => <th key={k}>{k}</th>)}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r, i) => (
+                <tr key={i}>
+                  {Object.keys(rows[0]).map((k) => <td key={k}>{String(r[k])}</td>)}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <button onClick={exportCSV} style={{ marginTop: 12 }}>
+            Export CSV
+          </button>
+        </>
+      )}
+    </main>
+  );
+}
+
+export default Metrics;

--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+
+const API = process.env.REACT_APP_API_BASE || "http://127.0.0.1:8000";
+
+function Upload()
+{
+  const [file, setFile] = useState(null);
+  const [msg, setMsg] = useState("");
+
+  async function handleSubmit(e)
+  {
+    e.preventDefault();
+    if (!file)
+    {
+      setMsg("Please choose a .geojson or zipped shapefile (.zip).");
+      return;
+    }
+
+    try
+    {
+      const form = new FormData();
+      form.append("file", file); // FastAPI expects field named "file"
+      const res = await fetch(`${API}/upload-map`, {
+        method: "POST",
+        body: form,
+      });
+
+      if (!res.ok)
+      {
+        const text = await res.text();
+        throw new Error(text || `Upload failed (${res.status})`);
+      }
+
+      setMsg("Upload successful. Now go to the Metrics page.");
+    }
+    catch (err)
+    {
+      setMsg(`❌ ${err.message}`);
+    }
+  }
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h2>Upload District Map</h2>
+      <p>Tip: use the example at <code>backend/example.geojson</code>.</p>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="file"
+          accept=".geojson,.zip"
+          onChange={(e) => setFile(e.target.files?.[0] || null)}
+        />
+        <button type="submit" style={{ marginLeft: 12 }}>Upload</button>
+      </form>
+      <p style={{ marginTop: 12 }}>{msg}</p>
+    </main>
+  );
+}
+
+export default Upload;


### PR DESCRIPTION
## Summary
This adds the first working frontend and connects it to the FastAPI backend.

### Frontend
- Pages: Upload, Metrics, About
- Upload -> POST /upload-map
- Metrics -> POST /calculate-metrics
- Export -> POST /export-report
- Simple nav (Home / Upload / Metrics / About)

### Backend
- CORS enabled for local dev (http://localhost:3000 and http://127.0.0.1:3000)
- No other behavior changes

## How to run (local)
**Backend**
```bash
cd backend
conda activate fairmap   # or venv
uvicorn main:app --reload --port 8000

## Frontend
cd frontend
npm install
npm start


## Notes
- Tested with backend/example.geojson
- CSV downloads as report.csv from Metrics page

Screenshots (local test)

Upload success
https://github.com/user-attachments/assets/f114d13e-bf0c-4252-b0e9-41c813771c94

Metrics table
https://github.com/user-attachments/assets/53a1a14b-053a-498f-bef7-eff75c497dae

CSV export
https://github.com/user-attachments/assets/a214c2f8-fe4a-4ee5-a6db-286feb15f766
