### PR TITLE
feat(metrics): add Polsby–Popper + per-district table

### DIFF
--- a/frontend/src/pages/Metrics.jsx
+++ b/frontend/src/pages/Metrics.jsx
@@ -3,77 +3,63 @@ import { useState } from "react";
 
 const API = process.env.REACT_APP_API_BASE || "http://127.0.0.1:8000";
 
-function Metrics()
-{
+function Metrics() {
   const [file, setFile] = useState(null);
   const [rows, setRows] = useState([]);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState("");
 
-  async function calculate(e)
-  {
+  async function calculate(e) {
     e.preventDefault();
-    if (!file)
-    {
+    if (!file) {
       setErr("Please choose the same .geojson (or .zip shapefile) you uploaded.");
       return;
     }
 
-    try
-    {
+    try {
       setBusy(true);
       setErr("");
+      setRows([]);
       const form = new FormData();
       form.append("file", file);
 
-      // Backend expects POST multipart/form-data
       const res = await fetch(`${API}/calculate-metrics`, {
         method: "POST",
         body: form,
       });
 
-      if (!res.ok)
-      {
+      if (!res.ok) {
         const text = await res.text();
         throw new Error(text || `HTTP ${res.status}`);
       }
 
       const data = await res.json();
-      // Accept either { metrics: {...} } or an array normalize to table rows
       const m = data.metrics;
-      if (Array.isArray(m))
-      {
+
+      if (m && m.summary && Array.isArray(m.per_district)) {
+        // flatten into one list of rows
+        const rowsOut = [];
+        rowsOut.push({ type: "summary", ...m.summary });
+        m.per_district.forEach((d) => rowsOut.push({ type: "district", ...d }));
+        setRows(rowsOut);
+      } else if (Array.isArray(m)) {
         setRows(m);
-      }
-      else if (m && typeof m === "object")
-      {
-        // If it's an object (for example {num_districts, compactness, efficiency_gap})
-        // show it as one-row table.
-        const objAsRow = { ...m };
-        setRows([objAsRow]);
-      }
-      else
-      {
+      } else if (m && typeof m === "object") {
+        setRows([{ type: "summary", ...m }]);
+      } else {
         setRows([]);
       }
-    }
-    catch (e)
-    {
-      setErr(e.message);
+    } catch (e) {
+      setErr(e?.message || String(e));
       setRows([]);
-    }
-    finally
-    {
+    } finally {
       setBusy(false);
     }
   }
 
-  async function exportCSV()
-  {
-    try
-    {
-      if (rows.length === 0)
-      {
+  async function exportCSV() {
+    try {
+      if (rows.length === 0) {
         setErr("No metrics to export. Click Calculate first.");
         return;
       }
@@ -84,25 +70,30 @@ function Metrics()
         body: JSON.stringify({ metrics: rows })
       });
 
-      if (!res.ok)
-      {
+      if (!res.ok) {
         const text = await res.text();
         throw new Error(text || `Export failed (${res.status})`);
       }
 
       const blob = await res.blob();
+      let filename = "report.csv";
+      const cd = res.headers.get("content-disposition");
+      const match = cd && /filename="?([^"]+)"?/i.exec(cd);
+      if (match && match[1]) filename = match[1];
+
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = "report.csv";
+      a.download = filename;
       a.click();
       window.URL.revokeObjectURL(url);
-    }
-    catch (e)
-    {
-      setErr(e.message);
+    } catch (e) {
+      setErr(e?.message || String(e));
     }
   }
+
+  // collect all possible keys across rows for headers
+  const allKeys = Array.from(new Set(rows.flatMap(r => Object.keys(r))));
 
   return (
     <main style={{ padding: 24 }}>
@@ -112,11 +103,26 @@ function Metrics()
         <input
           type="file"
           accept=".geojson,.zip"
-          onChange={(e) => setFile(e.target.files?.[0] || null)}
+          disabled={busy}
+          onChange={(e) => {
+            setFile(e.target.files?.[0] || null);
+            setErr("");
+            setRows([]);
+          }}
         />
-        <button type="submit" disabled={busy} style={{ marginLeft: 8 }}>
+        <button
+          type="submit"
+          disabled={busy || !file}
+          style={{ marginLeft: 8 }}
+        >
           {busy ? "Calculating…" : "Calculate"}
         </button>
+
+        {file && !busy && (
+          <span style={{ marginLeft: 8, opacity: 0.7 }}>
+            Selected: {file.name}
+          </span>
+        )}
       </form>
 
       {err && <p style={{ color: "red" }}>Error: {err}</p>}
@@ -129,19 +135,25 @@ function Metrics()
           <table border="1" cellPadding="8">
             <thead>
               <tr>
-                {Object.keys(rows[0]).map((k) => <th key={k}>{k}</th>)}
+                {allKeys.map((k) => <th key={k}>{k}</th>)}
               </tr>
             </thead>
             <tbody>
               {rows.map((r, i) => (
                 <tr key={i}>
-                  {Object.keys(rows[0]).map((k) => <td key={k}>{String(r[k])}</td>)}
+                  {allKeys.map((k) => (
+                    <td key={k}>{r[k] !== undefined ? String(r[k]) : "-"}</td>
+                  ))}
                 </tr>
               ))}
             </tbody>
           </table>
 
-          <button onClick={exportCSV} style={{ marginTop: 12 }}>
+          <button
+            onClick={exportCSV}
+            style={{ marginTop: 12 }}
+            disabled={busy || rows.length === 0}
+          >
             Export CSV
           </button>
         </>


### PR DESCRIPTION
Updates metrics to include real compactness calculation.

- Added Polsby–Popper formula in backend (overall + per-district).
- Frontend now shows both summary and per-district rows in the table.
- CSV export includes all values.

Tested locally with Supervisorial_Districts.geojson and confirmed:
- Upload works
- Metrics table renders summary + districts
- CSV downloads clean

Next steps (future PRs):
- Add Leaflet map viewer
- Implement more metrics (efficiency gap, population deviation)
- Improve UI/UX for metrics page